### PR TITLE
a more strict nick regex

### DIFF
--- a/irc/strings.go
+++ b/irc/strings.go
@@ -9,7 +9,7 @@ import (
 var (
 	// regexps
 	ChannelNameExpr = regexp.MustCompile(`^[&!#+][\pL\pN]{1,63}$`)
-	NicknameExpr    = regexp.MustCompile("^[\\pL\\pN\\pP\\pS]{1,32}$")
+	NicknameExpr    = regexp.MustCompile("^([A-Za-z_\\\\^`{|}[\\]][A-Za-z0-9_\\-\\\\^`{|}[\\]]*)+$")
 )
 
 // Names are normalized and canonicalized to remove formatting marks


### PR DESCRIPTION
A more strict rule for nicknames :

only accepting: 0-9A-z[]^_`{|}-
cannot begin with digit or dash
